### PR TITLE
add nulls to dropdown to clear

### DIFF
--- a/OpenIPC_Config/ViewModels/CameraSettingsTabViewModel.cs
+++ b/OpenIPC_Config/ViewModels/CameraSettingsTabViewModel.cs
@@ -258,7 +258,25 @@ public partial class CameraSettingsTabViewModel : ViewModelBase
     
     private void UpdateCombinedValue()
     {
-        CombinedFpvRoiRectValue = $"{FpvRoiRectLeft[0]}x{FpvRoiRectTop[0]}x{FpvRoiRectHeight[0]}x{FpvRoiRectWidth[0]}";
+        var fpvRoiRectLeft = FpvRoiRectLeft[0];
+        var fpvRoiRectTop = FpvRoiRectTop[0];
+        var fpvRoiRectHeight = FpvRoiRectHeight[0];
+        var fpvRoiRectWidth = FpvRoiRectWidth[0];
+
+        if (string.IsNullOrEmpty(fpvRoiRectLeft) &&
+            string.IsNullOrEmpty(fpvRoiRectTop) &&
+            string.IsNullOrEmpty(fpvRoiRectHeight) &&
+            string.IsNullOrEmpty(fpvRoiRectWidth)
+           )
+        {
+            // set to empty so that it removes the settings
+            CombinedFpvRoiRectValue = "";
+        }
+        else
+        {
+            CombinedFpvRoiRectValue = $"{FpvRoiRectLeft[0]}x{FpvRoiRectTop[0]}x{FpvRoiRectHeight[0]}x{FpvRoiRectWidth[0]}";    
+        }
+        
         Log.Debug($"Combined value updated to {CombinedFpvRoiRectValue}");
         UpdateYamlConfig(Majestic.FpvRoiRect, CombinedFpvRoiRectValue);
     }
@@ -269,7 +287,13 @@ public partial class CameraSettingsTabViewModel : ViewModelBase
             _yamlConfig[key] = newValue;
         else
             _yamlConfig.Add(key, newValue);
+
+        if (string.IsNullOrEmpty(newValue))
+        {
+            _yamlConfig.Remove(key);
+        }
     }
+    
     
     private void InitializeCollections()
     {
@@ -298,17 +322,22 @@ public partial class CameraSettingsTabViewModel : ViewModelBase
         Mirror = new ObservableCollection<string> { "true", "false" };
         
         FpvEnabled = new ObservableCollection<string> { "true", "false" };
-        FpvNoiseLevel = new ObservableCollection<string> { "0", "1", "2" };
+        FpvNoiseLevel = new ObservableCollection<string> { "","0", "1", "2" };
+        
         
         // Create an ObservableCollection with values from -30 to 30
         FpvRoiQp = new ObservableCollection<string>(Enumerable.Range(-30, 61).Select(i => i.ToString()));
+        FpvRoiQp.Insert(0,"");
         
         FpvRefEnhance = new ObservableCollection<string>(Enumerable.Range(0, 10).Select(i => i.ToString()));
+        FpvRefEnhance.Insert(0,"");
         
-        FpvRefPred = new ObservableCollection<string> { "true", "false" };
+        FpvRefPred = new ObservableCollection<string> { "", "true", "false" };
         
         FpvIntraLine = new ObservableCollection<string>(Enumerable.Range(0, 10).Select(i => i.ToString()));
-        FpvIntraQp = new ObservableCollection<string>{ "true", "false" };
+        FpvIntraLine.Insert(0,"");
+        
+        FpvIntraQp = new ObservableCollection<string>{ "","true", "false" };
 
         FpvRoiRectLeft = new ObservableCollection<string> { "" };
     }


### PR DESCRIPTION
## Description

merge fix for Camera FPV Settings cannot clear once set, rect is setting --- when empty

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #47

## Motivation and Context

Camera FPV Settings cannot clear once set, rect is setting --- when empty

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
