### PR TITLE
Keep firmware UI elements in sync, fix bugs

### DIFF
--- a/OpenIPC_Config.Tests/ViewModels/FirmwareTabViewModelTests.cs
+++ b/OpenIPC_Config.Tests/ViewModels/FirmwareTabViewModelTests.cs
@@ -112,7 +112,7 @@ public class FirmwareTabViewModelTests
     public void CanExecuteDownloadFirmware_ReturnsFalse_IfInvalidState()
     {
         // Arrange
-        _viewModel.ManualFirmwareFile = null;
+        _viewModel.ManualLocalFirmwarePackageFile = null;
         _viewModel.SelectedManufacturer = null;
         _viewModel.SelectedDevice = null;
         _viewModel.SelectedFirmware = null;
@@ -128,7 +128,7 @@ public class FirmwareTabViewModelTests
     public void CanExecuteDownloadFirmware_ReturnsTrue_IfValidState()
     {
         // Arrange
-        _viewModel.ManualFirmwareFile = "test.tgz";
+        _viewModel.ManualLocalFirmwarePackageFile = "test.tgz";
 
         // Act
         var canExecute = _viewModel.DownloadFirmwareAsyncCommand.CanExecute(null);

--- a/OpenIPC_Config/Views/FirmwareTabView.axaml
+++ b/OpenIPC_Config/Views/FirmwareTabView.axaml
@@ -104,15 +104,15 @@
                                  Background="#F0F0F0"
                                  Width="400"
                                  Height="25"
-                                 IsEnabled="{Binding CanUseSelectFirmware}"
-                                 Text="{Binding Path=ManualFirmwareFile, Mode=TwoWay}" />
+                                 IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
+                                 Text="{Binding Path=ManualLocalFirmwarePackageFile, Mode=TwoWay}" />
                         
                         <Button Grid.Row="0" Grid.Column="2" Content="..."
                                 Margin="5,5,0,0"
                                 VerticalAlignment="Center"
                                 Background="LightGray"
-                                IsEnabled="{Binding CanUseSelectFirmware}"
-                                Command="{Binding SelectFirmwareCommand}"
+                                IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
+                                Command="{Binding SelectLocalFirmwarePackageCommand}"
                                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
 
                     </Grid>


### PR DESCRIPTION
* Keep [manufacturer->device->firmware combo], [firmware package dropdown] and [local firmware package] in sync;
(Clear button is obsolete now, but I don't know yet how to properly remove it in Avalonia)

* Fix crash when connecting on the firmware tab;

* Other bug fixes;

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
