### PR TITLE
Added support for Wyvern Link(Now we have ttyS3!!)

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -277,56 +277,117 @@ jobs:
             rsvg-convert -w 256 -h 256 OpenIPC.svg -o OpenIPC.png
           fi
 
-      - name: Create ARM64 AppImage (alternative to Flatpak)
+      - name: Create ARM64 portable package (alternative to Flatpak)
         run: |
-          # Create AppDir structure
-          mkdir -p OpenIPC_Config.AppDir/usr/bin
-          mkdir -p OpenIPC_Config.AppDir/usr/share/applications
-          mkdir -p OpenIPC_Config.AppDir/usr/share/icons/hicolor/256x256/apps
+          # Create a simple portable package structure
+          mkdir -p OpenIPC_Config-linux-arm64/bin
+          mkdir -p OpenIPC_Config-linux-arm64/share/applications
+          mkdir -p OpenIPC_Config-linux-arm64/share/icons
           
           # Copy binary
-          cp -r build/OpenIPC_Config.Desktop/linux-arm64/* OpenIPC_Config.AppDir/usr/bin/
-          chmod +x OpenIPC_Config.AppDir/usr/bin/OpenIPC_Config.Desktop
+          cp -r build/OpenIPC_Config.Desktop/linux-arm64/* OpenIPC_Config-linux-arm64/bin/
+          chmod +x OpenIPC_Config-linux-arm64/bin/OpenIPC_Config.Desktop
           
           # Create desktop file
-          cat > OpenIPC_Config.AppDir/OpenIPC_Config.desktop << 'EOF'
+          cat > OpenIPC_Config-linux-arm64/share/applications/com.openipc.OpenIPC_Config.desktop << 'EOF'
           [Desktop Entry]
           Type=Application
           Name=OpenIPC Config
+          GenericName=Camera Configuration Tool
+          Comment=Configuration tool for OpenIPC cameras
           Exec=OpenIPC_Config.Desktop
-          Icon=OpenIPC_Config
+          Icon=com.openipc.OpenIPC_Config
           Categories=Network;Settings;
+          Keywords=camera;openipc;configuration;network;
+          StartupNotify=true
           EOF
-          
-          # Copy desktop file
-          cp OpenIPC_Config.AppDir/OpenIPC_Config.desktop OpenIPC_Config.AppDir/usr/share/applications/
           
           # Copy icon
-          cp OpenIPC.png OpenIPC_Config.AppDir/usr/share/icons/hicolor/256x256/apps/OpenIPC_Config.png
-          cp OpenIPC.png OpenIPC_Config.AppDir/OpenIPC_Config.png
+          cp OpenIPC.png OpenIPC_Config-linux-arm64/share/icons/
           
-          # Create AppRun script
-          cat > OpenIPC_Config.AppDir/AppRun << 'EOF'
+          # Create run script
+          cat > OpenIPC_Config-linux-arm64/run.sh << 'EOF'
           #!/bin/bash
-          cd "$(dirname "$0")"
-          exec ./usr/bin/OpenIPC_Config.Desktop "$@"
+          # OpenIPC Config Launcher
+          SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+          cd "$SCRIPT_DIR"
+          exec ./bin/OpenIPC_Config.Desktop "$@"
           EOF
-          chmod +x OpenIPC_Config.AppDir/AppRun
+          chmod +x OpenIPC_Config-linux-arm64/run.sh
           
-          # Download and use appimagetool
-          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-          chmod +x appimagetool-x86_64.AppImage
+          # Create installation script
+          cat > OpenIPC_Config-linux-arm64/install.sh << 'EOF'
+          #!/bin/bash
+          # OpenIPC Config Installation Script
           
-          # Create AppImage (will be marked as aarch64 compatible)
-          ARCH=aarch64 ./appimagetool-x86_64.AppImage OpenIPC_Config.AppDir OpenIPC_Config-aarch64.AppImage
+          INSTALL_DIR="$HOME/.local/share/OpenIPC_Config"
+          DESKTOP_FILE="$HOME/.local/share/applications/com.openipc.OpenIPC_Config.desktop"
+          ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
           
-          echo "Created ARM64 AppImage as an alternative to Flatpak"
+          echo "Installing OpenIPC Config..."
+          
+          # Create directories
+          mkdir -p "$INSTALL_DIR"
+          mkdir -p "$(dirname "$DESKTOP_FILE")"
+          mkdir -p "$ICON_DIR"
+          
+          # Copy files
+          cp -r bin share "$INSTALL_DIR/"
+          cp run.sh "$INSTALL_DIR/"
+          
+          # Install desktop file
+          sed "s|Exec=OpenIPC_Config.Desktop|Exec=$INSTALL_DIR/run.sh|g" \
+              share/applications/com.openipc.OpenIPC_Config.desktop > "$DESKTOP_FILE"
+          
+          # Install icon
+          cp share/icons/OpenIPC.png "$ICON_DIR/com.openipc.OpenIPC_Config.png"
+          
+          # Update desktop database
+          if command -v update-desktop-database >/dev/null 2>&1; then
+              update-desktop-database "$HOME/.local/share/applications"
+          fi
+          
+          echo "✅ OpenIPC Config installed successfully!"
+          echo "You can run it from the applications menu or with: $INSTALL_DIR/run.sh"
+          EOF
+          chmod +x OpenIPC_Config-linux-arm64/install.sh
+          
+          # Create README
+          cat > OpenIPC_Config-linux-arm64/README.md << 'EOF'
+          # OpenIPC Config - ARM64 Linux Package
+          
+          ## Quick Start
+          ```bash
+          ./run.sh
+          ```
+          
+          ## Installation
+          ```bash
+          ./install.sh
+          ```
+          This will install the application to `~/.local/share/OpenIPC_Config` and add a desktop entry.
+          
+          ## Manual Installation
+          1. Extract this package to your preferred location
+          2. Run `./run.sh` to start the application
+          3. Optionally, create a symlink: `ln -s $(pwd)/run.sh ~/.local/bin/openipc-config`
+          
+          ## Requirements
+          - Linux ARM64 system
+          - .NET runtime dependencies (usually pre-installed)
+          EOF
+          
+          # Create tar.gz package
+          tar -czf OpenIPC_Config-linux-arm64.tar.gz OpenIPC_Config-linux-arm64/
+          
+          echo "✅ ARM64 portable package created successfully"
+          ls -la OpenIPC_Config-linux-arm64.tar.gz
 
-      - name: Upload ARM64 AppImage
+      - name: Upload ARM64 package
         uses: actions/upload-artifact@v4
         with:
-          name: appimage-aarch64
-          path: OpenIPC_Config-aarch64.AppImage
+          name: package-aarch64
+          path: OpenIPC_Config-linux-arm64.tar.gz
 
   create-release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -343,17 +404,17 @@ jobs:
           pattern: flatpak-*
           merge-multiple: true
 
-      - name: Download ARM64 AppImage
+      - name: Download ARM64 package
         uses: actions/download-artifact@v4
         with:
-          name: appimage-aarch64
+          name: package-aarch64
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             *.flatpak
-            *.AppImage
+            *.tar.gz
           body: |
             ## OpenIPC Config ${{ github.ref_name }}
             
@@ -366,11 +427,17 @@ jobs:
             flatpak run com.openipc.OpenIPC_Config
             ```
             
-            **AppImage (For ARM64/aarch64):**
-            Download `OpenIPC_Config-aarch64.AppImage` and run with:
+            **Portable Package (For ARM64/aarch64):**
+            Download `OpenIPC_Config-linux-arm64.tar.gz`, extract and run:
             ```bash
-            chmod +x OpenIPC_Config-aarch64.AppImage
-            ./OpenIPC_Config-aarch64.AppImage
+            tar -xzf OpenIPC_Config-linux-arm64.tar.gz
+            cd OpenIPC_Config-linux-arm64
+            ./run.sh
+            ```
+            
+            Or install system-wide:
+            ```bash
+            ./install.sh
             ```
             
             ### Changes

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,13 +1,5 @@
 name: Build and Package Flatpak
 
-concurrency:
-  group: build-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: write
-  actions: read
-
 on:
 #  push:
 #    branches: [ main, develop ]
@@ -16,6 +8,13 @@ on:
 #    branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: read
 
 env:
   DOTNET_VERSION: '8.0.x'  # Adjust to your .NET version
@@ -69,12 +68,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flatpak-arch: [x86_64, aarch64]
         include:
           - flatpak-arch: x86_64
             dotnet-arch: linux-x64
-          - flatpak-arch: aarch64
-            dotnet-arch: linux-arm64
+            cross-compile: false
+          # Note: aarch64 Flatpak cross-compilation is complex in GitHub Actions
+          # The aarch64 .NET binary will be packaged in a separate job if needed
 
     steps:
       - name: Checkout code
@@ -221,7 +220,7 @@ jobs:
           # Create repo directory
           mkdir -p repo
           
-          # Build the Flatpak
+          # Build the Flatpak for x86_64
           flatpak-builder --arch=${{ matrix.flatpak-arch }} --force-clean --repo=repo \
             flatpak-build ${{ env.APP_ID }}.yml
           
@@ -235,45 +234,143 @@ jobs:
           name: flatpak-${{ matrix.flatpak-arch }}
           path: ${{ env.APP_ID }}-${{ matrix.flatpak-arch }}.flatpak
 
+  # Separate job for ARM64 using a simpler approach
+  build-flatpak-arm64:
+    needs: build-dotnet
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download ARM64 build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dotnet-build-linux-arm64
+          path: build/OpenIPC_Config.Desktop/linux-arm64/
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y imagemagick librsvg2-bin
+
+      - name: Create application icon
+        run: |
+          # Check if icon exists in the repository
+          if [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.png" ]; then
+            cp "OpenIPC_Config/Assets/Icons/OpenIPC.png" ./OpenIPC.png
+          elif [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.icns" ]; then
+            # Convert icns to png
+            convert "OpenIPC_Config/Assets/Icons/OpenIPC.icns[0]" -resize 256x256 OpenIPC.png
+          else
+            # Create a placeholder icon
+            cat > OpenIPC.svg << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+            <rect width="256" height="256" fill="#4a90e2" rx="32"/>
+            <circle cx="128" cy="100" r="40" fill="white" stroke="#333" stroke-width="4"/>
+            <rect x="88" y="120" width="80" height="60" fill="white" stroke="#333" stroke-width="4" rx="8"/>
+            <text x="128" y="200" text-anchor="middle" fill="white" font-family="sans-serif" font-size="16" font-weight="bold">OpenIPC</text>
+            <text x="128" y="220" text-anchor="middle" fill="white" font-family="sans-serif" font-size="12">Config</text>
+          </svg>
+          EOF
+            rsvg-convert -w 256 -h 256 OpenIPC.svg -o OpenIPC.png
+          fi
+
+      - name: Create ARM64 AppImage (alternative to Flatpak)
+        run: |
+          # Create AppDir structure
+          mkdir -p OpenIPC_Config.AppDir/usr/bin
+          mkdir -p OpenIPC_Config.AppDir/usr/share/applications
+          mkdir -p OpenIPC_Config.AppDir/usr/share/icons/hicolor/256x256/apps
+          
+          # Copy binary
+          cp -r build/OpenIPC_Config.Desktop/linux-arm64/* OpenIPC_Config.AppDir/usr/bin/
+          chmod +x OpenIPC_Config.AppDir/usr/bin/OpenIPC_Config.Desktop
+          
+          # Create desktop file
+          cat > OpenIPC_Config.AppDir/OpenIPC_Config.desktop << 'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=OpenIPC Config
+          Exec=OpenIPC_Config.Desktop
+          Icon=OpenIPC_Config
+          Categories=Network;Settings;
+          EOF
+          
+          # Copy desktop file
+          cp OpenIPC_Config.AppDir/OpenIPC_Config.desktop OpenIPC_Config.AppDir/usr/share/applications/
+          
+          # Copy icon
+          cp OpenIPC.png OpenIPC_Config.AppDir/usr/share/icons/hicolor/256x256/apps/OpenIPC_Config.png
+          cp OpenIPC.png OpenIPC_Config.AppDir/OpenIPC_Config.png
+          
+          # Create AppRun script
+          cat > OpenIPC_Config.AppDir/AppRun << 'EOF'
+          #!/bin/bash
+          cd "$(dirname "$0")"
+          exec ./usr/bin/OpenIPC_Config.Desktop "$@"
+          EOF
+          chmod +x OpenIPC_Config.AppDir/AppRun
+          
+          # Download and use appimagetool
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          
+          # Create AppImage (will be marked as aarch64 compatible)
+          ARCH=aarch64 ./appimagetool-x86_64.AppImage OpenIPC_Config.AppDir OpenIPC_Config-aarch64.AppImage
+          
+          echo "Created ARM64 AppImage as an alternative to Flatpak"
+
+      - name: Upload ARM64 AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage-aarch64
+          path: OpenIPC_Config-aarch64.AppImage
+
   create-release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build-flatpak
+    needs: [build-flatpak, build-flatpak-arm64]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all Flatpak artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: flatpak-*
           merge-multiple: true
+
+      - name: Download ARM64 AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: appimage-aarch64
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             *.flatpak
+            *.AppImage
           body: |
             ## OpenIPC Config ${{ github.ref_name }}
             
             ### Installation
             
-            Download the appropriate Flatpak bundle for your architecture:
-            - `com.openipc.OpenIPC_Config-x86_64.flatpak` for 64-bit Intel/AMD systems
-            - `com.openipc.OpenIPC_Config-aarch64.flatpak` for 64-bit ARM systems
-            
-            Install with:
+            **Flatpak (Recommended for x86_64):**
+            Download `com.openipc.OpenIPC_Config-x86_64.flatpak` and install with:
             ```bash
             flatpak install --user --bundle com.openipc.OpenIPC_Config-x86_64.flatpak
+            flatpak run com.openipc.OpenIPC_Config
             ```
             
-            Run with:
+            **AppImage (For ARM64/aarch64):**
+            Download `OpenIPC_Config-aarch64.AppImage` and run with:
             ```bash
-            flatpak run com.openipc.OpenIPC_Config
+            chmod +x OpenIPC_Config-aarch64.AppImage
+            ./OpenIPC_Config-aarch64.AppImage
             ```
             
             ### Changes

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,11 +1,11 @@
 name: Build and Package Flatpak
 
 on:
-#  push:
-#    branches: [ main, develop ]
-#    tags: [ 'v*' ]
-#  pull_request:
-#    branches: [ main ]
+  push:
+    branches: [ main, develop ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:
@@ -116,6 +116,35 @@ jobs:
             rsvg-convert -w 256 -h 256 OpenIPC.svg -o OpenIPC.png
           fi
 
+      - name: Prepare configuration files
+        run: |
+          # Check if config files exist in the source and copy them
+          if [ -d "OpenIPC_Config/config" ]; then
+            echo "Found config directory in source, copying..."
+            cp -r OpenIPC_Config/config ./
+          elif [ -d "config" ]; then
+            echo "Found config directory in root, using it..."
+          else
+            echo "No config directory found, will create default in Flatpak build"
+            mkdir -p config/OpenIPC_Config
+            cat > config/OpenIPC_Config/appsettings.json << 'EOF'
+          {
+            "Logging": {
+              "LogLevel": {
+                "Default": "Information",
+                "Microsoft.AspNetCore": "Warning"
+              }
+            },
+            "AllowedHosts": "*",
+            "AppSettings": {
+              "DefaultTheme": "Dark",
+              "AutoSave": true,
+              "CheckForUpdates": true
+            }
+          }
+          EOF
+          fi
+
       - name: Create Flatpak manifest
         run: |
           cat > ${{ env.APP_ID }}.yml << 'EOF'
@@ -129,11 +158,14 @@ jobs:
           finish-args:
             - --share=network
             - --filesystem=home
+            - --filesystem=xdg-config:rw
+            - --filesystem=xdg-data:rw
             - --socket=x11
             - --socket=wayland
             - --socket=pulseaudio
             - --device=all
             - --talk-name=org.freedesktop.Notifications
+            - --env=XDG_DATA_DIRS=/app/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share
           
           modules:
             - name: openipc-config
@@ -142,6 +174,27 @@ jobs:
                 - mkdir -p /app/bin
                 - cp -r ${{ matrix.dotnet-arch }}/* /app/bin/
                 - chmod +x /app/bin/OpenIPC_Config.Desktop
+                # Copy config files if they exist
+                - |
+                  if [ -d "config" ]; then
+                    cp -r config /app/bin/
+                  fi
+                # Create default config if it doesn't exist
+                - mkdir -p /app/bin/config/OpenIPC_Config
+                - |
+                  if [ ! -f "/app/bin/config/OpenIPC_Config/appsettings.json" ]; then
+                    cat > /app/bin/config/OpenIPC_Config/appsettings.json << 'CONFIG_EOF'
+                  {
+                    "Logging": {
+                      "LogLevel": {
+                        "Default": "Information",
+                        "Microsoft.AspNetCore": "Warning"
+                      }
+                    },
+                    "AllowedHosts": "*"
+                  }
+                  CONFIG_EOF
+                  fi
                 - mkdir -p /app/share/applications
                 - cp com.openipc.OpenIPC_Config.desktop /app/share/applications/
                 - mkdir -p /app/share/icons/hicolor/256x256/apps
@@ -152,6 +205,9 @@ jobs:
               sources:
                 - type: dir
                   path: build/OpenIPC_Config.Desktop/
+                - type: dir
+                  path: config/
+                  dest: config
                 - type: file
                   path: com.openipc.OpenIPC_Config.desktop
                 - type: file

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,11 +1,11 @@
 name: Build and Package Flatpak
 
 on:
-  push:
-    branches: [ main, develop ]
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
+#  push:
+#    branches: [ main, develop ]
+#    tags: [ 'v*' ]
+#  pull_request:
+#    branches: [ main ]
   workflow_dispatch:
 
 concurrency:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux-x64, linux-arm64]
+        arch: [linux-x64]
     
     steps:
       - name: Checkout code
@@ -166,6 +166,16 @@ jobs:
             - --device=all
             - --talk-name=org.freedesktop.Notifications
             - --env=XDG_DATA_DIRS=/app/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share
+            # Network and system access for ping functionality
+            - --share=network
+            - --system-talk-name=org.freedesktop.NetworkManager
+            - --system-talk-name=org.freedesktop.resolve1
+            # Allow access to network tools and raw sockets (for ping)
+            - --filesystem=/usr/bin/ping:ro
+            - --filesystem=/bin/ping:ro
+            - --allow=devel
+            # Alternative: allow running host commands
+            - --talk-name=org.freedesktop.Flatpak
           
           modules:
             - name: openipc-config

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -16,6 +16,7 @@ on:
 #    branches: [ main ]
   workflow_dispatch:
 
+
 env:
   DOTNET_VERSION: '8.0.x'  # Adjust to your .NET version
   APP_ID: 'com.openipc.OpenIPC_Config'
@@ -25,8 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux-x64]
-        #arch: [linux-x64, linux-arm64]
+        arch: [linux-x64, linux-arm64]
     
     steps:
       - name: Checkout code
@@ -37,11 +37,18 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore dependencies (Desktop only)
+        run: dotnet restore OpenIPC_Config.Desktop
 
-      - name: Run tests
-        run: dotnet test --logger "trx;LogFileName=TestResults.xml"
+      - name: Run tests (if test project exists)
+        run: |
+          if [ -d "OpenIPC_Config.Tests" ]; then
+            dotnet test OpenIPC_Config.Tests --logger "trx;LogFileName=TestResults.xml"
+          elif [ -d "tests" ]; then
+            dotnet test tests --logger "trx;LogFileName=TestResults.xml"
+          else
+            echo "No test project found, skipping tests"
+          fi
 
       - name: Build for ${{ matrix.arch }}
         run: |

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,11 +1,11 @@
 name: Build and Package Flatpak
 
 on:
-#  push:
-#    branches: [ main, develop ]
-#    tags: [ 'v*' ]
-#  pull_request:
-#    branches: [ main ]
+  push:
+    branches: [ main, develop ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux-x64]
+        arch: [linux-x64, linux-arm64]
     
     steps:
       - name: Checkout code
@@ -66,14 +66,6 @@ jobs:
   build-flatpak:
     needs: build-dotnet
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - flatpak-arch: x86_64
-            dotnet-arch: linux-x64
-            cross-compile: false
-          # Note: aarch64 Flatpak cross-compilation is complex in GitHub Actions
-          # The aarch64 .NET binary will be packaged in a separate job if needed
 
     steps:
       - name: Checkout code
@@ -82,8 +74,8 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dotnet-build-${{ matrix.dotnet-arch }}
-          path: build/OpenIPC_Config.Desktop/${{ matrix.dotnet-arch }}/
+          name: dotnet-build-linux-x64
+          path: build/OpenIPC_Config.Desktop/linux-x64/
 
       - name: Install Flatpak and dependencies
         run: |
@@ -166,23 +158,21 @@ jobs:
             - --device=all
             - --talk-name=org.freedesktop.Notifications
             - --env=XDG_DATA_DIRS=/app/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share
-            # Network and system access for ping functionality
+            # Network access for ping and camera connectivity
             - --share=network
             - --system-talk-name=org.freedesktop.NetworkManager
             - --system-talk-name=org.freedesktop.resolve1
-            # Allow access to network tools and raw sockets (for ping)
-            - --filesystem=/usr/bin/ping:ro
-            - --filesystem=/bin/ping:ro
-            - --allow=devel
-            # Alternative: allow running host commands
+            # Allow spawning host processes for network tools
             - --talk-name=org.freedesktop.Flatpak
+            # Allow development/debugging tools (needed for some network operations)
+            - --allow=devel
           
           modules:
             - name: openipc-config
               buildsystem: simple
               build-commands:
                 - mkdir -p /app/bin
-                - cp -r ${{ matrix.dotnet-arch }}/* /app/bin/
+                - cp -r linux-x64/* /app/bin/
                 - chmod +x /app/bin/OpenIPC_Config.Desktop
                 # Copy config files if they exist
                 - |
@@ -201,7 +191,28 @@ jobs:
                         "Microsoft.AspNetCore": "Warning"
                       }
                     },
-                    "AllowedHosts": "*"
+                    "AllowedHosts": "*",
+                    "Serilog": {
+                      "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],
+                      "MinimumLevel": "Information",
+                      "WriteTo": [
+                        {
+                          "Name": "Console",
+                          "Args": {
+                            "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                          }
+                        },
+                        {
+                          "Name": "File",
+                          "Args": {
+                            "path": "~/.var/app/com.openipc.OpenIPC_Config/data/OpenIPC_Config/Logs/configurator.log",
+                            "rollingInterval": "Day",
+                            "retainedFileCountLimit": "5",
+                            "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                          }
+                        }
+                      ]
+                    }
                   }
                   CONFIG_EOF
                   fi
@@ -287,223 +298,48 @@ jobs:
           mkdir -p repo
           
           # Build the Flatpak for x86_64
-          flatpak-builder --arch=${{ matrix.flatpak-arch }} --force-clean --repo=repo \
+          flatpak-builder --arch=x86_64 --force-clean --repo=repo \
             flatpak-build ${{ env.APP_ID }}.yml
           
           # Create bundle
-          flatpak build-bundle repo ${{ env.APP_ID }}-${{ matrix.flatpak-arch }}.flatpak \
-            ${{ env.APP_ID }} --arch=${{ matrix.flatpak-arch }}
+          flatpak build-bundle repo ${{ env.APP_ID }}-x86_64.flatpak \
+            ${{ env.APP_ID }} --arch=x86_64
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@v4
         with:
-          name: flatpak-${{ matrix.flatpak-arch }}
-          path: ${{ env.APP_ID }}-${{ matrix.flatpak-arch }}.flatpak
-
-  # Separate job for ARM64 using a simpler approach
-  build-flatpak-arm64:
-    needs: build-dotnet
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download ARM64 build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dotnet-build-linux-arm64
-          path: build/OpenIPC_Config.Desktop/linux-arm64/
-
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y imagemagick librsvg2-bin
-
-      - name: Create application icon
-        run: |
-          # Check if icon exists in the repository
-          if [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.png" ]; then
-            cp "OpenIPC_Config/Assets/Icons/OpenIPC.png" ./OpenIPC.png
-          elif [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.icns" ]; then
-            # Convert icns to png
-            convert "OpenIPC_Config/Assets/Icons/OpenIPC.icns[0]" -resize 256x256 OpenIPC.png
-          else
-            # Create a placeholder icon
-            cat > OpenIPC.svg << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-            <rect width="256" height="256" fill="#4a90e2" rx="32"/>
-            <circle cx="128" cy="100" r="40" fill="white" stroke="#333" stroke-width="4"/>
-            <rect x="88" y="120" width="80" height="60" fill="white" stroke="#333" stroke-width="4" rx="8"/>
-            <text x="128" y="200" text-anchor="middle" fill="white" font-family="sans-serif" font-size="16" font-weight="bold">OpenIPC</text>
-            <text x="128" y="220" text-anchor="middle" fill="white" font-family="sans-serif" font-size="12">Config</text>
-          </svg>
-          EOF
-            rsvg-convert -w 256 -h 256 OpenIPC.svg -o OpenIPC.png
-          fi
-
-      - name: Create ARM64 portable package (alternative to Flatpak)
-        run: |
-          # Create a simple portable package structure
-          mkdir -p OpenIPC_Config-linux-arm64/bin
-          mkdir -p OpenIPC_Config-linux-arm64/share/applications
-          mkdir -p OpenIPC_Config-linux-arm64/share/icons
-          
-          # Copy binary
-          cp -r build/OpenIPC_Config.Desktop/linux-arm64/* OpenIPC_Config-linux-arm64/bin/
-          chmod +x OpenIPC_Config-linux-arm64/bin/OpenIPC_Config.Desktop
-          
-          # Create desktop file
-          cat > OpenIPC_Config-linux-arm64/share/applications/com.openipc.OpenIPC_Config.desktop << 'EOF'
-          [Desktop Entry]
-          Type=Application
-          Name=OpenIPC Config
-          GenericName=Camera Configuration Tool
-          Comment=Configuration tool for OpenIPC cameras
-          Exec=OpenIPC_Config.Desktop
-          Icon=com.openipc.OpenIPC_Config
-          Categories=Network;Settings;
-          Keywords=camera;openipc;configuration;network;
-          StartupNotify=true
-          EOF
-          
-          # Copy icon
-          cp OpenIPC.png OpenIPC_Config-linux-arm64/share/icons/
-          
-          # Create run script
-          cat > OpenIPC_Config-linux-arm64/run.sh << 'EOF'
-          #!/bin/bash
-          # OpenIPC Config Launcher
-          SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-          cd "$SCRIPT_DIR"
-          exec ./bin/OpenIPC_Config.Desktop "$@"
-          EOF
-          chmod +x OpenIPC_Config-linux-arm64/run.sh
-          
-          # Create installation script
-          cat > OpenIPC_Config-linux-arm64/install.sh << 'EOF'
-          #!/bin/bash
-          # OpenIPC Config Installation Script
-          
-          INSTALL_DIR="$HOME/.local/share/OpenIPC_Config"
-          DESKTOP_FILE="$HOME/.local/share/applications/com.openipc.OpenIPC_Config.desktop"
-          ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
-          
-          echo "Installing OpenIPC Config..."
-          
-          # Create directories
-          mkdir -p "$INSTALL_DIR"
-          mkdir -p "$(dirname "$DESKTOP_FILE")"
-          mkdir -p "$ICON_DIR"
-          
-          # Copy files
-          cp -r bin share "$INSTALL_DIR/"
-          cp run.sh "$INSTALL_DIR/"
-          
-          # Install desktop file
-          sed "s|Exec=OpenIPC_Config.Desktop|Exec=$INSTALL_DIR/run.sh|g" \
-              share/applications/com.openipc.OpenIPC_Config.desktop > "$DESKTOP_FILE"
-          
-          # Install icon
-          cp share/icons/OpenIPC.png "$ICON_DIR/com.openipc.OpenIPC_Config.png"
-          
-          # Update desktop database
-          if command -v update-desktop-database >/dev/null 2>&1; then
-              update-desktop-database "$HOME/.local/share/applications"
-          fi
-          
-          echo "✅ OpenIPC Config installed successfully!"
-          echo "You can run it from the applications menu or with: $INSTALL_DIR/run.sh"
-          EOF
-          chmod +x OpenIPC_Config-linux-arm64/install.sh
-          
-          # Create README
-          cat > OpenIPC_Config-linux-arm64/README.md << 'EOF'
-          # OpenIPC Config - ARM64 Linux Package
-          
-          ## Quick Start
-          ```bash
-          ./run.sh
-          ```
-          
-          ## Installation
-          ```bash
-          ./install.sh
-          ```
-          This will install the application to `~/.local/share/OpenIPC_Config` and add a desktop entry.
-          
-          ## Manual Installation
-          1. Extract this package to your preferred location
-          2. Run `./run.sh` to start the application
-          3. Optionally, create a symlink: `ln -s $(pwd)/run.sh ~/.local/bin/openipc-config`
-          
-          ## Requirements
-          - Linux ARM64 system
-          - .NET runtime dependencies (usually pre-installed)
-          EOF
-          
-          # Create tar.gz package
-          tar -czf OpenIPC_Config-linux-arm64.tar.gz OpenIPC_Config-linux-arm64/
-          
-          echo "✅ ARM64 portable package created successfully"
-          ls -la OpenIPC_Config-linux-arm64.tar.gz
-
-      - name: Upload ARM64 package
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-aarch64
-          path: OpenIPC_Config-linux-arm64.tar.gz
+          name: flatpak-x86_64
+          path: ${{ env.APP_ID }}-x86_64.flatpak
 
   create-release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-flatpak, build-flatpak-arm64]
+    needs: build-flatpak
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download Flatpak artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: flatpak-*
-          merge-multiple: true
-
-      - name: Download ARM64 package
-        uses: actions/download-artifact@v4
-        with:
-          name: package-aarch64
+          name: flatpak-x86_64
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             *.flatpak
-            *.tar.gz
           body: |
             ## OpenIPC Config ${{ github.ref_name }}
             
             ### Installation
             
-            **Flatpak (Recommended for x86_64):**
+            **Flatpak (Linux x86_64):**
             Download `com.openipc.OpenIPC_Config-x86_64.flatpak` and install with:
             ```bash
             flatpak install --user --bundle com.openipc.OpenIPC_Config-x86_64.flatpak
             flatpak run com.openipc.OpenIPC_Config
-            ```
-            
-            **Portable Package (For ARM64/aarch64):**
-            Download `OpenIPC_Config-linux-arm64.tar.gz`, extract and run:
-            ```bash
-            tar -xzf OpenIPC_Config-linux-arm64.tar.gz
-            cd OpenIPC_Config-linux-arm64
-            ./run.sh
-            ```
-            
-            Or install system-wide:
-            ```bash
-            ./install.sh
             ```
             
             ### Changes

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,277 @@
+name: Build and Package Flatpak
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: read
+
+on:
+#  push:
+#    branches: [ main, develop ]
+#    tags: [ 'v*' ]
+#  pull_request:
+#    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '8.0.x'  # Adjust to your .NET version
+  APP_ID: 'com.openipc.OpenIPC_Config'
+
+jobs:
+  build-dotnet:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [linux-x64]
+        #arch: [linux-x64, linux-arm64]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Run tests
+        run: dotnet test --logger "trx;LogFileName=TestResults.xml"
+
+      - name: Build for ${{ matrix.arch }}
+        run: |
+          mkdir -p build/OpenIPC_Config.Desktop/${{ matrix.arch }}
+          dotnet publish OpenIPC_Config.Desktop -c Release -r ${{ matrix.arch }} \
+            --output "build/OpenIPC_Config.Desktop/${{ matrix.arch }}" \
+            --self-contained -p:PublishSingleFile=true
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-build-${{ matrix.arch }}
+          path: build/OpenIPC_Config.Desktop/${{ matrix.arch }}/
+          retention-days: 1
+
+  build-flatpak:
+    needs: build-dotnet
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flatpak-arch: [x86_64, aarch64]
+        include:
+          - flatpak-arch: x86_64
+            dotnet-arch: linux-x64
+          - flatpak-arch: aarch64
+            dotnet-arch: linux-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dotnet-build-${{ matrix.dotnet-arch }}
+          path: build/OpenIPC_Config.Desktop/${{ matrix.dotnet-arch }}/
+
+      - name: Install Flatpak and dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y flatpak flatpak-builder imagemagick librsvg2-bin
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install -y flathub org.freedesktop.Platform//23.08
+          sudo flatpak install -y flathub org.freedesktop.Sdk//23.08
+
+      - name: Create application icon
+        run: |
+          # Check if icon exists in the repository
+          if [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.png" ]; then
+            cp "OpenIPC_Config/Assets/Icons/OpenIPC.png" ./OpenIPC.png
+          elif [ -f "OpenIPC_Config/Assets/Icons/OpenIPC.icns" ]; then
+            # Convert icns to png
+            convert "OpenIPC_Config/Assets/Icons/OpenIPC.icns[0]" -resize 256x256 OpenIPC.png
+          else
+            # Create a placeholder icon
+            cat > OpenIPC.svg << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+            <rect width="256" height="256" fill="#4a90e2" rx="32"/>
+            <circle cx="128" cy="100" r="40" fill="white" stroke="#333" stroke-width="4"/>
+            <rect x="88" y="120" width="80" height="60" fill="white" stroke="#333" stroke-width="4" rx="8"/>
+            <text x="128" y="200" text-anchor="middle" fill="white" font-family="sans-serif" font-size="16" font-weight="bold">OpenIPC</text>
+            <text x="128" y="220" text-anchor="middle" fill="white" font-family="sans-serif" font-size="12">Config</text>
+          </svg>
+          EOF
+            rsvg-convert -w 256 -h 256 OpenIPC.svg -o OpenIPC.png
+          fi
+
+      - name: Create Flatpak manifest
+        run: |
+          cat > ${{ env.APP_ID }}.yml << 'EOF'
+          app-id: com.openipc.OpenIPC_Config
+          runtime: org.freedesktop.Platform
+          runtime-version: '23.08'
+          sdk: org.freedesktop.Sdk
+          command: OpenIPC_Config.Desktop
+          separate-locales: false
+          
+          finish-args:
+            - --share=network
+            - --filesystem=home
+            - --socket=x11
+            - --socket=wayland
+            - --socket=pulseaudio
+            - --device=all
+            - --talk-name=org.freedesktop.Notifications
+          
+          modules:
+            - name: openipc-config
+              buildsystem: simple
+              build-commands:
+                - mkdir -p /app/bin
+                - cp -r ${{ matrix.dotnet-arch }}/* /app/bin/
+                - chmod +x /app/bin/OpenIPC_Config.Desktop
+                - mkdir -p /app/share/applications
+                - cp com.openipc.OpenIPC_Config.desktop /app/share/applications/
+                - mkdir -p /app/share/icons/hicolor/256x256/apps
+                - cp OpenIPC.png /app/share/icons/hicolor/256x256/apps/com.openipc.OpenIPC_Config.png
+                - mkdir -p /app/share/metainfo
+                - cp com.openipc.OpenIPC_Config.metainfo.xml /app/share/metainfo/
+          
+              sources:
+                - type: dir
+                  path: build/OpenIPC_Config.Desktop/
+                - type: file
+                  path: com.openipc.OpenIPC_Config.desktop
+                - type: file
+                  path: com.openipc.OpenIPC_Config.metainfo.xml
+                - type: file
+                  path: OpenIPC.png
+          EOF
+
+      - name: Create desktop file
+        run: |
+          cat > ${{ env.APP_ID }}.desktop << 'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=OpenIPC Config
+          GenericName=Camera Configuration Tool
+          Comment=Configuration tool for OpenIPC cameras
+          Exec=OpenIPC_Config.Desktop
+          Icon=com.openipc.OpenIPC_Config
+          Categories=Network;Settings;
+          Keywords=camera;openipc;configuration;network;
+          StartupNotify=true
+          EOF
+
+      - name: Create metainfo file
+        run: |
+          # Get version from tag or use default
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION="1.0.0"
+          fi
+          
+          cat > ${{ env.APP_ID }}.metainfo.xml << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <component type="desktop-application">
+            <id>com.openipc.OpenIPC_Config</id>
+            <name>OpenIPC Config</name>
+            <summary>Configuration tool for OpenIPC cameras</summary>
+            <description>
+              <p>
+                OpenIPC Config is a comprehensive configuration tool for OpenIPC camera systems.
+                It provides an easy-to-use interface for managing camera settings, network configuration,
+                and system parameters.
+              </p>
+            </description>
+            <launchable type="desktop-id">com.openipc.OpenIPC_Config.desktop</launchable>
+            <screenshots>
+              <screenshot type="default">
+                <caption>Main application window</caption>
+                <image>https://openipc.org/screenshot.png</image>
+              </screenshot>
+            </screenshots>
+            <url type="homepage">https://openipc.org</url>
+            <url type="bugtracker">https://github.com/OpenIPC/OpenIPC_Config/issues</url>
+            <metadata_license>CC0-1.0</metadata_license>
+            <project_license>GPL-3.0+</project_license>
+            <releases>
+              <release version="${VERSION}" date="$(date +%Y-%m-%d)"/>
+            </releases>
+            <content_rating type="oars-1.1"/>
+          </component>
+          EOF
+
+      - name: Build Flatpak
+        run: |
+          # Create repo directory
+          mkdir -p repo
+          
+          # Build the Flatpak
+          flatpak-builder --arch=${{ matrix.flatpak-arch }} --force-clean --repo=repo \
+            flatpak-build ${{ env.APP_ID }}.yml
+          
+          # Create bundle
+          flatpak build-bundle repo ${{ env.APP_ID }}-${{ matrix.flatpak-arch }}.flatpak \
+            ${{ env.APP_ID }} --arch=${{ matrix.flatpak-arch }}
+
+      - name: Upload Flatpak bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: flatpak-${{ matrix.flatpak-arch }}
+          path: ${{ env.APP_ID }}-${{ matrix.flatpak-arch }}.flatpak
+
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-flatpak
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all Flatpak artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: flatpak-*
+          merge-multiple: true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.flatpak
+          body: |
+            ## OpenIPC Config ${{ github.ref_name }}
+            
+            ### Installation
+            
+            Download the appropriate Flatpak bundle for your architecture:
+            - `com.openipc.OpenIPC_Config-x86_64.flatpak` for 64-bit Intel/AMD systems
+            - `com.openipc.OpenIPC_Config-aarch64.flatpak` for 64-bit ARM systems
+            
+            Install with:
+            ```bash
+            flatpak install --user --bundle com.openipc.OpenIPC_Config-x86_64.flatpak
+            ```
+            
+            Run with:
+            ```bash
+            flatpak run com.openipc.OpenIPC_Config
+            ```
+            
+            ### Changes
+            - See commit history for detailed changes
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/OpenIPC_Config/ViewModels/TelemetryTabViewModel.cs
+++ b/OpenIPC_Config/ViewModels/TelemetryTabViewModel.cs
@@ -163,7 +163,7 @@ public partial class TelemetryTabViewModel : ViewModelBase
     #region Initialization Methods
     private void InitializeCollections()
     {
-        SerialPorts = new ObservableCollection<string> { "ttyS0", "ttyS1", "ttyS2" };
+        SerialPorts = new ObservableCollection<string> { "ttyS0", "ttyS1", "ttyS2", "ttyS3" };
         BaudRates = new ObservableCollection<string> { "4800", "9600", "19200", "38400", "57600", "115200" };
         McsIndex = new ObservableCollection<string> { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
         Aggregate = new ObservableCollection<string> { "0", "1", "2", "4", "6", "8", "10", "12", "14", "15" };


### PR DESCRIPTION
## Description

Added support for Wyvern Link(Now we have ttyS3!!). Before that you couldn't setup MSPOSD or another router on Wyvern Link if you connected it to FC using plug connector 

## Related Issue
Issue 139

This PR fixes or closes issue: closes 139

## Motivation and Context
Broadens number of supported VTXes

## How Has This Been Tested
No testers were found to test this feature. But it was tested on WiFiLink v1 and results are on screenshot below.
![image](https://github.com/user-attachments/assets/ca72c2c4-ed57-4e92-b589-7dfe3cde46e1)


## Types of changes


-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


-   [x ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x ] I have updated the documentation accordingly.
-   [ x] I have tested the change locally.
