### PR TITLE
Fix firmware flash reporting success when it actually failed

### DIFF
--- a/Companion/Services/SshClientService.cs
+++ b/Companion/Services/SshClientService.cs
@@ -106,7 +106,11 @@ public class SshClientService : ISshClientService
                 }
                 catch (Exception ex)
                 {
+                    // Do NOT swallow: a failed upload must surface so the caller can
+                    // abort the flash instead of proceeding against a missing/partial
+                    // file and reporting a false success.
                     _logger.Error($"Error uploading file: {ex.Message}");
+                    throw;
                 }
                 finally
                 {

--- a/Companion/Services/SysUpgradeService.cs
+++ b/Companion/Services/SysUpgradeService.cs
@@ -24,18 +24,14 @@ public class SysUpgradeService
     {
         try
         {
-            updateProgress("Uploading kernel...");
             string kernelFilename = Path.GetFileName(kernelPath);
             var remoteKernelPath = $"{OpenIPC.RemoteTempFolder}/{kernelFilename}";
-            await _sshClientService.UploadFileAsync(deviceConfig, kernelPath, remoteKernelPath);
-            await ValidateRemoteFileSizeAsync(deviceConfig, kernelPath, remoteKernelPath, "kernel", updateProgress, cancellationToken);
+            await UploadAndVerifyWithRetryAsync(deviceConfig, kernelPath, remoteKernelPath, "kernel", updateProgress, cancellationToken);
             updateProgress("Kernel binary uploaded successfully.");
 
-            updateProgress("Uploading root filesystem...");
             string rootfsFilename = Path.GetFileName(rootfsPath);
             var remoteRootfsPath = $"{OpenIPC.RemoteTempFolder}/{rootfsFilename}";
-            await _sshClientService.UploadFileAsync(deviceConfig, rootfsPath, remoteRootfsPath);
-            await ValidateRemoteFileSizeAsync(deviceConfig, rootfsPath, remoteRootfsPath, "rootfs", updateProgress, cancellationToken);
+            await UploadAndVerifyWithRetryAsync(deviceConfig, rootfsPath, remoteRootfsPath, "rootfs", updateProgress, cancellationToken);
             updateProgress("Root filesystem binary uploaded successfully.");
 
             updateProgress("Starting sysupgrade. Do not unplug the device.");
@@ -56,6 +52,48 @@ public class SysUpgradeService
         {
             _logger.Error(ex, "Error during sysupgrade.");
             updateProgress($"Error: {ex.Message}");
+            // Re-throw so the caller does NOT report a successful flash when the
+            // upload/verification/flash actually failed. A swallowed exception here
+            // is what made a failed flash look identical to a successful one.
+            throw;
+        }
+    }
+
+    private const int UploadMaxAttempts = 3;
+
+    /// <summary>
+    /// Uploads a file and verifies it landed at full size on the device, retrying on
+    /// failure. SCP uploads over flaky links (e.g. dropbear) can fail or truncate; without
+    /// verification the flash would proceed against a missing/partial file. Throws if all
+    /// attempts fail so the caller can abort instead of bricking or faking success.
+    /// </summary>
+    private async Task UploadAndVerifyWithRetryAsync(
+        DeviceConfig deviceConfig,
+        string localPath,
+        string remotePath,
+        string label,
+        Action<string> updateProgress,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                updateProgress(attempt == 1
+                    ? $"Uploading {label}..."
+                    : $"Uploading {label}... (attempt {attempt}/{UploadMaxAttempts})");
+                await _sshClientService.UploadFileAsync(deviceConfig, localPath, remotePath);
+                await ValidateRemoteFileSizeAsync(deviceConfig, localPath, remotePath, label, updateProgress, cancellationToken);
+                return;
+            }
+            catch (Exception ex) when (attempt < UploadMaxAttempts)
+            {
+                _logger.Warning(ex, "Upload of {Label} failed on attempt {Attempt}/{Max}; retrying.",
+                    label, attempt, UploadMaxAttempts);
+                updateProgress($"Upload of {label} failed (attempt {attempt}/{UploadMaxAttempts}); retrying...");
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+            }
         }
     }
 

--- a/Companion/ViewModels/FirmwareTabViewModel.cs
+++ b/Companion/ViewModels/FirmwareTabViewModel.cs
@@ -2420,6 +2420,14 @@ public partial class FirmwareTabViewModel : ViewModelBase
             SetProgressBarBrush(ProgressErrorBrush);
             _sysupgradeInProgress = false;
             _sysupgradePhase = SysupgradePhase.None;
+            // Tell the user the flash failed. Previously the upload/sysupgrade swallowed
+            // its exception, so this catch never fired and the success dialog ran anyway —
+            // the device was left on its old firmware while the UI claimed it was flashed.
+            await _messageBoxService.ShowCustomMessageBox(
+                "Upgrade failed",
+                $"The firmware was NOT flashed. The device is still on its previous firmware.\n\n{ex.Message}\n\nCheck the connection and try again.",
+                ButtonEnum.Ok,
+                Icon.Error);
         }
     }
 


### PR DESCRIPTION
## Problem

A failed firmware flash is reported to the user as a success. The device is left on its old firmware while the UI shows 100% and "Upgrade Complete!! Device has been flashed!"

Root cause is a chain of swallowed exceptions:
1. SshClientService.UploadFileAsync catches upload errors and does not rethrow — a failed SCP upload returns as success.
2. SysUpgradeService.PerformSysupgradeAsync catches upload + wc -c size-verification + sysupgrade in one try/catch that only logs — no rethrow. So even when the size check detects the file never landed, it is swallowed.
3. FirmwareTabViewModel.UpgradeFirmwareFromFileAsync then unconditionally sets ProgressValue = 100 and shows the success dialog without checking whether the flash happened.

Especially easy to hit on dropbear cameras where the Renci.SshNet ScpClient upload can fail/truncate: upload silently no-ops, device never gets the files, UI still claims success (unchanged GITHUB_VERSION banner, no rootfs change).

## Fix
- UploadFileAsync: rethrow after logging.
- PerformSysupgradeAsync: rethrow after logging; add UploadAndVerifyWithRetryAsync (3 attempts, 2s backoff) so flaky-link upload failures recover instead of proceeding against a missing file.
- UpgradeFirmwareFromFileAsync: show explicit "Upgrade failed" dialog on error.

## Testing
- dotnet build — 0 errors (pre-existing MVVMTK0034 warnings only).
- dotnet test — all 60 tests pass.
